### PR TITLE
fix: Remove orphaned files from backups when untracked files are deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Repo Backup Tool CLI will be documented in this file.
 
 The format is based on [Keep a Changelog][Keep a Changelog url], and this project adheres to [Semantic Versioning][Semantic Versioning url].
 
+## [2.1.1] (22 December 2025)
+
+### Fixed
+
+1. Fixed bug where app did not delete removed files from backups.
+
 ## [2.1.0] (22 December 2025)
 
 ### Added
@@ -32,6 +38,7 @@ The format is based on [Keep a Changelog][Keep a Changelog url], and this projec
 
 [Keep a Changelog url]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning url]: https://semver.org/spec/v2.0.0.html
-[2.0.1]: https://github.com/SherpadNdabambi/repo-backup-tool-cli/releases/tag/v2.0.1
+[2.1.1]: https://github.com/SherpadNdabambi/repo-backup-tool-cli/releases/tag/v2.1.1
+[2.1.0]: https://github.com/SherpadNdabambi/repo-backup-tool-cli/releases/tag/v2.1.0
 [2.0.0]: https://github.com/SherpadNdabambi/repo-backup-tool-cli/releases/tag/v2.0.0
 [1.0.0]: https://github.com/SherpadNdabambi/repo-backup-tool-cli/releases/tag/v1.0.0

--- a/assets/ts/cli.ts
+++ b/assets/ts/cli.ts
@@ -6,7 +6,7 @@ import { Command } from "commander";
 const program = new Command()
   .description("A script to scan repos for unpushed changes and back them up.")
   .name("repo-backup-tool-cli")
-  .version("2.1.0");
+  .version("2.1.1");
 
 program.addCommand(backupCmd);
 

--- a/assets/ts/findOrphanedBackups.ts
+++ b/assets/ts/findOrphanedBackups.ts
@@ -1,0 +1,43 @@
+/**
+ * @file findOrphanedBackups.ts
+ * @description Module containing the findOrphanedBackups function
+ *
+ * @exports findOrphanedBackups
+ */
+import fsPromises from "fs/promises";
+import path from "path";
+
+/**
+ * Recursively walk backup directory
+ *
+ * @param {string} dir - The path to the directory
+ * @param {string} baseRel - The relative path to the directory
+ *
+ * @returns {Promise<void>} A promise that resolves when the cleanup is complete
+ */
+async function findOrphanedBackups(
+  dir: string,
+  baseRel = "",
+  expectedRelPaths: Set<string>,
+  orphanedFiles: string[] = []
+) {
+  const entries = await fsPromises.readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const rel = path.join(baseRel, entry.name).replace(/\\/g, "/");
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await findOrphanedBackups(full, rel, expectedRelPaths, orphanedFiles);
+      // Remove empty directories after recursion
+      const remaining = await fsPromises.readdir(full).catch(() => []);
+      if (remaining.length === 0) {
+        await fsPromises.rmdir(full);
+        console.log(` Removed empty directory: ${rel}/`);
+      }
+    } else !expectedRelPaths.has(rel) && orphanedFiles.push(rel);
+  }
+
+  return orphanedFiles;
+}
+
+export { findOrphanedBackups };

--- a/package.json
+++ b/package.json
@@ -46,5 +46,5 @@
     "test:unit": "jest --config jest.unit.config.ts"
   },
   "type": "module",
-  "version": "2.1.0"
+  "version": "2.1.1"
 }


### PR DESCRIPTION
Previously, when an untracked file was removed from a repository with an upstream branch, its backup copy was never deleted, leading to stale files in the backup.

This change:

1. Adds cleanup logic to detect and remove backup files that no longer exist in the repository (including deleted untracked files)
2. Extracts the orphaned file detection into a reusable `findOrphanedBackups` helper
3. Improves logging to distinguish tracked deletes from orphaned cleanup
4. Adds detailed delete logging for better visibility

Closes the gap in backup synchronization for repositories with remotes.

Bumps version to 2.1.1